### PR TITLE
adding api endpoint to allow search of artist by string name

### DIFF
--- a/backend/src/main/java/com/jos/spotifyclone/controller/SearchArtistController.java
+++ b/backend/src/main/java/com/jos/spotifyclone/controller/SearchArtistController.java
@@ -1,0 +1,26 @@
+package com.jos.spotifyclone.controller;
+
+import com.jos.spotifyclone.services.SpotifyConnect;
+import com.wrapper.spotify.exceptions.SpotifyWebApiException;
+import com.wrapper.spotify.model_objects.IModelObject;
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+
+@RequestMapping("api/search/artist")
+@RestController
+public class SearchArtistController<ArtistSearchRequest> {
+
+    @Autowired
+    SpotifyConnect spotifyConnect;
+
+    //TODO ${ARTIST_NAME_HERE} needs value storing elsewhere where this controller can access the search term to return searched for artist data
+    @GetMapping
+    public @ResponseBody
+    IModelObject searchArtistController() throws ParseException, IOException, SpotifyWebApiException {
+        return spotifyConnect.getSpotifyApi().searchArtists("${ARTIST_NAME_HERE}").build().execute();
+    }
+}


### PR DESCRIPTION
api endpoint add api/search/artist which allows user to search for an artist by string rather than providing artist_id. This works for now as an example but we may want to clean this up at a later date once other endpoints are created.