### PR TITLE
Linux and MacOSX support

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -40,6 +40,11 @@
 			<artifactId>spotify-web-api-java</artifactId>
 			<version>6.5.1</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.11</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/jos/spotifyclone/controller/AudioController.java
+++ b/backend/src/main/java/com/jos/spotifyclone/controller/AudioController.java
@@ -33,26 +33,26 @@ public class AudioController {
     }
 
     /**
-     * http://localhost:8080/api/audio/audio-features-track?id=01iyCAUm8EvOFqVWYJ3dVX
+     * http://localhost:8080/api/audio/audio-features/track?id=01iyCAUm8EvOFqVWYJ3dVX
      *
      * @param id
      * Required.
      * The Spotify ID for the track.
      */
-    @GetMapping("/audio-features-track")
+    @GetMapping("/audio-features/track")
     public AudioFeatures getAudioFeaturesForTrack(@RequestParam String id) throws ParseException, SpotifyWebApiException, IOException {
         return spotifyConnect.getSpotifyApi().getAudioFeaturesForTrack(id).build().execute();
     }
 
     /**
-     * http://localhost:8080/api/audio/audio-features-tracks?ids=01iyCAUm8EvOFqVWYJ3dVX
+     * http://localhost:8080/api/audio/audio-features/tracks?ids=01iyCAUm8EvOFqVWYJ3dVX
      *
      * @param ids
      * Required.
      * A comma-separated list of the Spotify IDs for the tracks.
      * Maximum: 100 IDs.
      */
-    @GetMapping("/audio-features-tracks")
+    @GetMapping("/audio-features/tracks")
     public AudioFeatures[] getAudioFeaturesForSeveralTracks(@RequestParam String[] ids) throws ParseException, SpotifyWebApiException, IOException {
         return spotifyConnect.getSpotifyApi().getAudioFeaturesForSeveralTracks(ids).build().execute();
     }

--- a/backend/src/main/java/com/jos/spotifyclone/controller/BrowseController.java
+++ b/backend/src/main/java/com/jos/spotifyclone/controller/BrowseController.java
@@ -30,7 +30,7 @@ public class BrowseController {
     //https://developer.spotify.com/console/get-available-genre-seeds/
     //http://localhost:8080/api/browse/recommended?seed=emo
     @GetMapping("/recommended")
-    public Map<String, Object> getRecommended(@RequestParam String seed) throws ParseException, SpotifyWebApiException, IOException {
+    public Map<String, Object> getRecommended(@RequestParam(defaultValue = "pop") String seed) throws ParseException, SpotifyWebApiException, IOException {
         var response = spotifyConnect.getSpotifyApi().getRecommendations().seed_genres(seed).build().execute();
 
         List<TrackModel> list = new ArrayList<>();

--- a/backend/src/main/java/com/jos/spotifyclone/controller/ExampleController.java
+++ b/backend/src/main/java/com/jos/spotifyclone/controller/ExampleController.java
@@ -7,7 +7,6 @@ import org.apache.hc.core5.http.ParseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
@@ -20,7 +19,7 @@ public class ExampleController {
     SpotifyConnect spotifyConnect;
 
     @GetMapping
-    public @ResponseBody User handleGet() throws ParseException, SpotifyWebApiException, IOException {
+    public User handleGet() throws ParseException, SpotifyWebApiException, IOException {
         return spotifyConnect.getSpotifyApi().getCurrentUsersProfile().build().execute();
     }
 

--- a/backend/src/main/java/com/jos/spotifyclone/services/SpotifyConnect.java
+++ b/backend/src/main/java/com/jos/spotifyclone/services/SpotifyConnect.java
@@ -6,10 +6,9 @@ import com.wrapper.spotify.exceptions.SpotifyWebApiException;
 import com.wrapper.spotify.model_objects.credentials.AuthorizationCodeCredentials;
 import com.wrapper.spotify.requests.authorization.authorization_code.AuthorizationCodeRequest;
 import com.wrapper.spotify.requests.authorization.authorization_code.AuthorizationCodeUriRequest;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.hc.core5.http.ParseException;
-import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.SpringVersion;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -57,15 +56,26 @@ public class SpotifyConnect {
     public void openAuthWindow() {
         final URI uri = authorizationCodeUriRequestBuilder.build().execute();
         Runtime runtime = Runtime.getRuntime();
-        try {
-            runtime.exec("rundll32 url.dll,FileProtocolHandler " + uri);
-        } catch (IOException e) {
-            System.out.println("If you're running on Windows and read this it looks like we can't open your browser...");
+        if(SystemUtils.IS_OS_WINDOWS){
+            try {
+                runtime.exec("rundll32 url.dll,FileProtocolHandler " + uri);
+            } catch (IOException e) {
+                System.out.println("If you're running on Windows and read this it looks like we can't open your browser...");
+            }
+       }
+        if(SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_MAC_OSX) {
+            try {
+                runtime.exec("open " + uri);
+            } catch (IOException e) {
+                System.out.println("If you're running on MacOS and read this it looks like we can't open your browser...");
+            }
         }
-        try {
-            runtime.exec("open " + uri);
-        } catch (IOException e) {
-            System.out.println("If you're running on MacOS and read this it looks like we can't open your browser...");
+        if(SystemUtils.IS_OS_LINUX){
+            try {
+                runtime.exec(new String[]{"bash", "-c", "xdg-open " + uri});
+            } catch (IOException e) {
+                System.out.println("If you're running on Linux and read this it looks like we can't open your browser...");
+            }
         }
     }
 


### PR DESCRIPTION
small changes: default seed for **recommended** endpoint,endpoints renamed
now we can open the auth with the default browser on any version of windows,linux,mac os